### PR TITLE
data-publish: separate .sql files from build

### DIFF
--- a/bench-data-publish/Documentation.md
+++ b/bench-data-publish/Documentation.md
@@ -5,9 +5,9 @@
 
 The command-line tool `bench-data-publish` is a utility for publishing the result of benchmarking run analysis to a Postgres DB.
 
-It also contains the DB schema, as well as a definition of views on the data stored within.
+It relies on separate SQL definitions of 1) a DB schema (i.e. tables for data) and 2) DB views on the data stored within.
 
-1. The schema is designed to only rely on an absolute minimum of data normalization; the `.json`s from a run and its analysis are stored verbatim the schema tables.
+1. The schema is designed to only utilize an absolute minimum of data normalization; the `.json`s from a run and its analysis are stored verbatim the schema tables.
 2. The views extract all relevant properties and metrics from those objects and expose them to make the data searchable and filterable.
 
 By using a service like PostgREST, a REST API can be served immediately from these views, without an addtional layer of configuration.

--- a/bench-data-publish/app/Command.hs
+++ b/bench-data-publish/app/Command.hs
@@ -17,8 +17,8 @@ data Command
   | Import FilePath
   | ImportAll FilePath
   | List
-  | Bootstrap String
-  | UpdateViews String
+  | Bootstrap FilePath
+  | UpdateViews FilePath String
   deriving Show
 
 data DBCredentials
@@ -79,10 +79,13 @@ parseConfig
           (Publish False <$> parseRunDirArg)
           "Unpublish specified run from API"
       , cmdParser "bootstrap"
-          (Bootstrap <$> strArgument (metavar "ROLE" <> help "Anonymous/read-only role on the DB"))
+          (Bootstrap <$> parseFileArg ".sql file containing table definitions")
           "Bootstrap schema onto DB, CLEARING PREVIOUS SCHEMA"
       , cmdParser "update-views"
-          (UpdateViews <$> strArgument (metavar "ROLE" <> help "Anonymous/read-only role on the DB"))
+          (UpdateViews
+            <$> parseFileArg ".sql file containing view definitions"
+            <*> strArgument (metavar "ROLE" <> help "Anonymous/read-only role on the DB")
+          )
           "Update API facing views in the schema only, not touching any tables or stored data"
       ]
     cmdParser cmd parser description = command cmd $ info parser $ progDesc description
@@ -124,5 +127,13 @@ parseRunDirArg
   = strArgument
     ( metavar "FILE|PATH"
     <> help "Path of a benchmarking run or its meta.json"
+    <> completer (bashCompleter "file")
+    )
+
+parseFileArg :: String -> Parser FilePath
+parseFileArg helpText
+  = strArgument
+    ( metavar "FILE"
+    <> help helpText
     <> completer (bashCompleter "file")
     )

--- a/bench-data-publish/bench-data-publish.cabal
+++ b/bench-data-publish/bench-data-publish.cabal
@@ -10,9 +10,6 @@ build-type:         Simple
 
 extra-doc-files:    Documentation.md
 
-data-files:         db/bench-data-tables.sql
-                    db/bench-data-views.sql
-
 
 executable bench-data-publish
     main-is:            Main.hs
@@ -22,9 +19,6 @@ executable bench-data-publish
                         Cardano.Benchmarking.Publish.DBSchema
                         Cardano.Benchmarking.Publish.Types
                         Command
-                        Paths_bench_data_publish
-
-    autogen-modules:    Paths_bench_data_publish
 
     if os(windows)
       buildable: False


### PR DESCRIPTION
Table and view definition `.sql` files are currently included in the build of `bench-data-publish`.
This PR separates the `.sql` from the build.

For the tool's commands `bootstrap` and `update-views`, an extra command line argument specifying the corresponding `.sql` file is now expected.