### PR TITLE
bench-data-publish: CLI calls and data can be wrapped up in JSON

### DIFF
--- a/bench-data-publish/Documentation.md
+++ b/bench-data-publish/Documentation.md
@@ -16,41 +16,50 @@ By using a service like PostgREST, a REST API can be served immediately from the
 ## Usage 
 
 ```
-Usage: bench-data-publish COMMAND
-                          [--pg-uri URI | --db ARG [-u ARG] [-p ARG] [-h ARG]
-                            [-P ARG]] (-s|--schema SCHEMA) [-f]
+Usage: bench-data-publish (COMMAND | COMMAND 
+                            [--pg-uri URI | --db ARG [-u ARG] [-p ARG] [-h ARG] 
+                              [-P ARG]] [-s SCHEMA] [-f])
 
 Available options:
-  --pg-uri URI             postgres[ql]:// URI of DB (default: $BECNH_DATA_PGURI)
+  --pg-uri URI             postgres[ql]:// URI of DB (default: $BENCH_DATA_PGURI)
   --db ARG                 DB name
   -u ARG                   DB user name (default: <your login name>)
   -p ARG                   DB password (default: $BENCH_DATA_PASS)
   -h ARG                   DB host (default: localhost)
   -P ARG                   DB port (default: 5432)
-  -s,--schema SCHEMA       DB schema to use
+  -s SCHEMA                DB schema to use (default: public)
   -f                       Force destructive operations (e.g. bootstrap)
 
 Available commands:
+  via-stdin                Expect command and payload as JSON via stdin
   import                   Import/update specified run
   import-all               Import/update all runs contained in directory
   list                     List all runs
   publish                  Publish specified run to API
   unpublish                Unpublish specified run from API
   bootstrap                Bootstrap schema onto DB, CLEARING PREVIOUS SCHEMA
-  update-views             Update API facing views in the schema only, not
-                           touching any tables or stored data
+  update-views             Only update API facing views for role in the schema, not touching any tables or stored data
 ```
 
 ### DB resource
 
 1. The specification of a DB resource is mandatory, either as a Postgres URI or via individual values.
    * The DB user should be owner of the DB specified; it needs privileges to `CREATE`, `DROP` and `GRANT`.
-2. The specification of a DB schema is mandatory; all DB objects that `bench-data-schema` touches reside in that schema only.
-3. For the `bootstrap` and `update-views` commmands, an unprivileged / anonymous DB role is needed.
-   * This role is intended for any API-side queries; for this role, `CREATE ROLE <anon_role> NOLOGIN;` is sufficient.
+2. The specification of a DB schema is optional, defaulting to `public`.
+   * All DB objects that `bench-data-publish` touches reside in that schema only.
+3. For the `update-views` commmand, an unprivileged / anonymous DB role is expected.
+   * This role is intended for any API-side read-only queries; for this role, `CREATE ROLE <anon_role> NOLOGIN;` is sufficient.
 
 ### API via PostgREST
 
 The API which PostgREST will eventually deliver is defined implicitly by the views in `db/bench-data-views.sql`.
 
 When `bench-data-publish` makes relevant changes to data or views, it runs appropriate actions for rebuilding materialized view(s), and notifying PostgREST to rebuild its schema cache. PostgREST itself will not need a restart.
+
+## Wrapping the CLI call in JSON
+
+Should the binary run on a remote machine, or in an isolated manner (e.g. inside a container), it is possible to pass the actual command, options and possibly data wrapped in JSON. The command `via-stdin` tells the binary to expect such an object piped through `stdin`.
+
+When `via-stdin` is used, no other command line options are expected. The result is represented as another JSON which can be received from `stdout`.
+
+The serializations for those objects are defined as `JSONWrapper.JSONWrapper` and `JSONWrapper.JSONResult`. `Main.toJSONWrapper` defines how command line arguments are encoded as JSON, which has to exactly match the `payload` attribute in the serialization. In `testing/` you can find a shell script (using `jq`) that conveniently constructs JSON values to pass via `stdin`.

--- a/bench-data-publish/app/Cardano/Benchmarking/Publish/DBQueries.hs
+++ b/bench-data-publish/app/Cardano/Benchmarking/Publish/DBQueries.hs
@@ -76,7 +76,7 @@ setResult schema
 
 
 -- returns whether the run has been created (True) or updated (False)
-dbStoreRun :: DBSchema -> ClusterRun -> DB.Session Bool
+dbStoreRun :: DBSchema -> ClusterRun ByteString -> DB.Session Bool
 dbStoreRun (DBSchema schemaName) ClusterRun{..}
   = do
     (runId, created) <-

--- a/bench-data-publish/app/Cardano/Benchmarking/Publish/Types.hs
+++ b/bench-data-publish/app/Cardano/Benchmarking/Publish/Types.hs
@@ -1,51 +1,72 @@
-{-# LANGUAGE DeriveGeneric       #-}
-{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module  Cardano.Benchmarking.Publish.Types where
 
-import           Data.ByteString.Char8  (ByteString)
-import           Data.Text              as T (Text, take, unpack)
-import           Data.Time.Clock        (UTCTime)
+import           Control.Applicative ((<|>))
+import           Data.Text as T (Text, take, unpack)
+import           Data.Time.Clock (UTCTime)
 import           Data.Time.Clock.System
-import           GHC.Generics           (Generic)
 
-import           Data.Aeson
+import           Data.Aeson as Aeson
 
 
-data ClusterRun
+data ClusterRun a
   = ClusterRun {
-      runMeta        :: !ByteString
-    , runBlockProp   :: !(Maybe ByteString)
-    , runClusterPerf :: !(Maybe ByteString)
+      runMeta        :: !a
+    , runBlockProp   :: !(Maybe a)
+    , runClusterPerf :: !(Maybe a)
     , metaStub       :: !MetaStub
     }
+    deriving (Functor)
+
+instance FromJSON a => FromJSON (ClusterRun a) where
+  parseJSON
+    = withObject "ClusterRun" $ \o ->
+      ClusterRun
+        <$> o .: "meta"
+        <*> o .:? "blockprop"
+        <*> o .:? "clusterperf"
+        <*> o .: "meta"
+
+instance ToJSON a => ToJSON (ClusterRun a) where
+  toJSON ClusterRun{..}
+    = object [
+          "meta"        .= runMeta
+        , "blockprop"   .= runBlockProp
+        , "clusterperf" .= runClusterPerf
+        ]
 
 -- we extract only very few attributes from meta.json to perform
 -- a necessary minimum of data normalization to describe a run
 data MetaStub
   = MetaStub {
       profile   :: Text
-    , batch     :: Text
+    , commit    :: Text
     , timestamp :: UTCTime
     }
-    deriving (Generic)
 
 instance Show MetaStub where
   show (MetaStub a b c)
     = concat [T.unpack (T.take 6 b), "--", show c, "--", T.unpack a]
 
 instance FromJSON MetaStub where
-    parseJSON = withObject "MetaStub" $ \o_ -> do
-      o <- o_ .: "meta"
-      pins <- o .: "pins"
-      MetaStub
-        <$> o .: "profile"
-        <*> pins .: "cardano-node"
-        <*> (systemToUTCTime <$> o .: "timestamp")
-
-test :: FilePath -> IO ()
-test metaJson = do
-    stub :: Either String MetaStub <-
-        eitherDecodeFileStrict metaJson
-    print stub
+  parseJSON v
+    = parseFromMetaJSON v <|> parseFromCLI v
+    where
+      parseFromMetaJSON
+        = withObject "MetaStub" $ \o_ -> do
+          o <- o_ .: "meta"
+          pins <- o .: "pins"
+          MetaStub
+            <$> o .: "profile"
+            <*> pins .: "cardano-node"
+            <*> (systemToUTCTime <$> o .: "timestamp")
+      parseFromCLI
+        = withObject "MetaStub" $ \o ->
+          MetaStub
+            <$> o .: "profile"
+            <*> o .: "commit"
+            <*> (systemToUTCTime <$> o .: "timestamp")

--- a/bench-data-publish/app/JSONWrapper.hs
+++ b/bench-data-publish/app/JSONWrapper.hs
@@ -20,7 +20,8 @@ import           GHC.Generics (Generic)
 import           Prelude hiding (error)
 
 import           Data.Aeson as Aeson
-import           Data.ByteString.Char8 (ByteString, toStrict)
+import           Data.ByteString.Char8 (ByteString)
+import           Data.ByteString.Lazy.Char8 (toStrict)
 import           Data.Text as T (Text, pack, unpack)
 
 import           Command (Command)

--- a/bench-data-publish/app/JSONWrapper.hs
+++ b/bench-data-publish/app/JSONWrapper.hs
@@ -1,0 +1,81 @@
+
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module JSONWrapper
+    ( AsValue
+    , JSONResult(..)
+    , JSONWrapper(..)
+    , resultError
+    , resultSuccess
+    , resultAsPlain
+    , valueToBS
+    )
+    where
+
+import           Data.Foldable (toList)
+import           GHC.Generics (Generic)
+import           Prelude hiding (error)
+
+import           Data.Aeson as Aeson
+import           Data.ByteString.Char8 (ByteString, toStrict)
+import           Data.Text as T (Text, pack, unpack)
+
+import           Command (Command)
+
+
+data JSONWrapper
+  = JSONWrapper
+    { command :: Command
+    , schema  :: Maybe String
+    , payload :: Maybe Aeson.Value
+    }
+    deriving (Generic)
+
+data JSONResult
+  = JSONResult
+    { exitcode  :: Int                          -- 0 is success
+    , result    :: Maybe Aeson.Value
+    , error     :: Maybe Text
+    }
+    deriving (Generic)
+
+
+jsonOptionsUnTaggedSum :: Options
+jsonOptionsUnTaggedSum
+  = defaultOptions {sumEncoding = ObjectWithSingleField}
+
+instance FromJSON JSONWrapper where
+  parseJSON   = genericParseJSON jsonOptionsUnTaggedSum
+
+instance ToJSON JSONResult where
+  toJSON     = genericToJSON jsonOptionsUnTaggedSum
+  toEncoding = genericToEncoding jsonOptionsUnTaggedSum
+
+resultError :: String -> JSONResult
+resultError err
+  = JSONResult (-1) Nothing (Just $ T.pack err)
+
+resultSuccess :: ToJSON a => a -> JSONResult
+resultSuccess res
+  = JSONResult 0 (Just $ toJSON res) Nothing
+
+resultAsPlain :: JSONResult -> (String, Int)
+resultAsPlain JSONResult{..}
+  | exitcode == 0   = (maybe "" go result, 0)
+  | otherwise       = (maybe "" T.unpack error, exitcode)
+  where
+    go :: Aeson.Value -> String
+    go (String t)   = T.unpack t
+    go (Array a)    = unlines $ map go $ toList a
+    go v            = show v
+
+newtype AsValue
+  = ValueWrapper {unWrap :: Aeson.Value}
+  deriving (FromJSON, ToJSON)
+
+valueToBS :: AsValue -> ByteString
+valueToBS
+  = toStrict . encode . unWrap

--- a/bench-data-publish/bench-data-publish.cabal
+++ b/bench-data-publish/bench-data-publish.cabal
@@ -19,6 +19,7 @@ executable bench-data-publish
                         Cardano.Benchmarking.Publish.DBSchema
                         Cardano.Benchmarking.Publish.Types
                         Command
+                        JSONWrapper
 
     if os(windows)
       buildable: False

--- a/bench-data-publish/testing/json_wrapper.jq
+++ b/bench-data-publish/testing/json_wrapper.jq
@@ -1,0 +1,20 @@
+# fully populate a JSON as payload for import
+def combine(m):
+    { meta:         m
+    , blockprop:    $bprop
+    , clusterperf:  $cperf
+    };
+
+# normalizes data from meta.json to match Cardano.Benchmarking.Publish.Types.MetaStub
+def normalize($m):
+    { profile:      $m.meta.profile
+    , commit:       $m.meta.pins."cardano-node"
+    , timestamp:    $m.meta.timestamp
+    };
+
+# wrap everything up into Main.JSONWrapper
+def wrap(p):
+    { command:      $cmd
+    , schema:       $schema
+    , payload:      p
+    };

--- a/bench-data-publish/testing/json_wrapper.sh
+++ b/bench-data-publish/testing/json_wrapper.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+SCRIPT=$0
+
+COMMAND=$1
+SCHEMA=$2
+ARG1=$3
+ARG2=$4
+
+META=""
+
+load_meta() {
+if [ ! -d "$ARG1" ]; then
+    echo "Error: run directory '${ARG1}' not found."
+    exit 1
+fi
+
+META="${ARG1}/meta.json"
+
+if [ ! -f "$META" ]; then
+    echo "Error: metadata '${META}' not found."
+    exit 1
+fi
+}
+
+# The command_XXX() functions construct a Main.JSONWrapper value.
+#
+# * The command must match the serialization of Command.Command
+# * The payload is the argument to the command and has to match
+#   the way CLI arguments are wrapped up in Main.toJSONWrapper
+
+command_list() {
+jq      -L "$SCRIPT_DIR"                           \
+        --arg cmd List                             \
+        --arg schema "$SCHEMA"                     \
+        --null-input                               \
+        'include "json_wrapper"; wrap(null)'
+}
+
+command_bootstrap() {
+local SQL=$1
+if [ ! -f "$SQL" ]; then
+    echo "Error: schema table definition .sql file '${SQL}' not found."
+    exit 1
+fi
+
+jq      -L "$SCRIPT_DIR"                           \
+        --arg cmd Bootstrap                        \
+        --arg schema "$SCHEMA"                     \
+        --rawfile sql $SQL                         \
+        --null-input                               \
+        'include "json_wrapper"; wrap([true, $sql])'
+# Note: the true literal here corresponds to -f (force) on the CLI
+}
+
+command_updateviews() {
+local ROLE=$1
+local SQL=$2
+if [ ! -f "$SQL" ]; then
+    echo "Error: schema view definition .sql file '${SQL}' not found."
+    exit 1
+fi
+
+jq      -L "$SCRIPT_DIR"                           \
+        --arg cmd UpdateViews                      \
+        --arg schema "$SCHEMA"                     \
+        --arg role "$ROLE"                         \
+        --rawfile sql $SQL                         \
+        --null-input                               \
+        'include "json_wrapper"; wrap([$role, $sql])'
+}   
+
+command_publish() {
+load_meta
+
+MODE=$(case "$COMMAND" in
+    publish)    echo true;;
+    unpublish)  echo false;;
+esac)
+
+jq      -L "$SCRIPT_DIR"                           \
+        --arg cmd Publish                          \
+        --arg schema "$SCHEMA"                     \
+        --argjson mode $MODE                       \
+        'include "json_wrapper"; normalize(.) | [$mode, .] | wrap(.)'   \
+        $META
+}
+
+command_import() {
+load_meta
+
+local BLOCKPROP="${ARG1}/analysis/blockprop.json"
+local CLUSTERPERF="${ARG1}/analysis/clusterperf.json"
+
+local ARG_BPROP="--argjson bprop null"
+local ARG_CPERF="--argjson cperf null"
+
+if [ -f "$BLOCKPROP" ]; then
+    ARG_BPROP="--slurpfile bprop ${BLOCKPROP}"
+fi
+
+if [ -f "$CLUSTERPERF" ]; then
+    ARG_CPERF="--slurpfile cperf ${CLUSTERPERF}"
+fi
+
+jq      -L "$SCRIPT_DIR"                            \
+        --arg cmd Import                            \
+        --arg schema "$SCHEMA"                      \
+        $ARG_BPROP                                  \
+        $ARG_CPERF                                  \
+        'include "json_wrapper"; combine(.) | wrap(.)'  \
+        $META
+}
+
+usage() {
+    echo "usage: $SCRIPT <command> <schema> [<arg1>, ...]"
+    echo "  where (by command):"
+    echo "    import        <schema> <rundir>           -- Import/update specified run in the DB schema"
+    echo "    list          <schema>                    -- List all runs in the DB schema"
+    echo "    publish       <schema> <rundir>           -- Publish specified run to API"
+    echo "    unpublish     <schema> <rundir>           -- Unpublish specified run from API"
+    echo "    bootstrap     <schema> <file.sql>         -- Bootstrap schema onto DB, CLEARING PREVIOUS SCHEMA"
+    echo "    update-views  <schema> <role> <file.sql>  -- Only update API facing views for role in the schema"
+    exit 1;
+}
+
+main() {
+case "$COMMAND" in
+    list)                   command_list;;
+    publish | unpublish)    command_publish;;
+    import)                 command_import;;
+    bootstrap)              command_bootstrap $ARG1;;
+    update-views)           command_updateviews $ARG1 $ARG2;;
+    *)                      echo "Error: unknown command '${COMMAND}'"; exit 1;;
+esac
+}
+
+[[ -z "$@" ]] && usage
+if [ -z "$SCHEMA" ]; then
+    echo "Error: please specify DB schema."
+    exit 1
+fi
+main
+exit 0;


### PR DESCRIPTION
This PR adds the capability to `bench-data-publish` to wrap command line arguments, options and data in JSON which can be piped through `stdin`.

This functionality is an option when the the executable runs in an isolated manner (e.g. in a container) and/or cannot readily access the data to be published via file system calls.